### PR TITLE
replace deprecated add-path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Install cask
         run: |
           git clone https://github.com/cask/cask ~/.cask
-          echo "::add-path::${HOME}/.cask/bin"
+          echo "${HOME}/.cask/bin" >> $GITHUB_PATH
       - name: Run tests
         run: make test


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/