### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Introduction
 
-`helm-ag2.el` provides interfaces of [The Silver Searcher](https://github.com/ggreer/the_silver_searcher) with helm.
-`helm-ag2.el` also supports [ripgrep](https://github.com/BurntSushi/ripgrep)
+`helm-ag2.el` provides interfaces of [The Silver Searcher](https://github.com/ggreer/the_silver_searcher) and [ripgrep](https://github.com/BurntSushi/ripgrep) with helm.
+
+`helm-ag2.el` uses `rg` command if ripgrep is installed, otherwise it uses `ag` command. `ripgrep` must be built with `pcre2` feature.
 
 
 ## Features
@@ -102,10 +103,6 @@ You can set the parameter same as `thing-at-point`(Such as `'word`, `symbol` etc
 
 Save buffers you edit at editing completed.
 
-#### NOTE
-
-`helm` removes `file-line` type feature from 1.6.9. So `helm-ag2-source-type` is no longer available.
-
 
 ## Keymap
 
@@ -149,15 +146,5 @@ current line indicates.
 ```lisp
 (custom-set-variables
  '(helm-ag2-base-command '("ag" "--nocolor" "--nogroup" "--ignore-case"))
- '(helm-ag2-insert-at-point 'symbol)
- '(helm-ag2-ignore-buffer-patterns '("\\.txt\\'" "\\.mkd\\'")))
-```
-
-## ripgrep
-
-You need to build `ripgrep` with `pcre` feature for using all features of `helm-ag2`
-
-```lisp
-(custom-set-variables
- '(helm-ag-base-command '("rg" "--pcre2" "--color=never" "--vimgrep")))
+ '(helm-ag2-insert-at-point 'symbol))
 ```

--- a/helm-ag2.el
+++ b/helm-ag2.el
@@ -40,9 +40,6 @@
   "the silver searcher with helm interface"
   :group 'helm)
 
-(defsubst helm-ag2--windows-p ()
-  (memq system-type '(ms-dos windows-nt)))
-
 (defcustom helm-ag2-base-command
   (if (executable-find "rg")
       '("rg" "--pcre2" "--color=never" "--no-heading" "--line-number")
@@ -154,13 +151,6 @@
       (setq args (append args (helm-ag2--construct-targets helm-ag2--default-target))))
     (cons command args)))
 
-(defun helm-ag2--remove-carrige-returns ()
-  (when (helm-ag2--windows-p)
-    (save-excursion
-      (goto-char (point-min))
-      (while (re-search-forward "\xd" nil t)
-        (replace-match "")))))
-
 (defun helm-ag2--init ()
   (let ((buf-coding buffer-file-coding-system))
     (helm-set-attr 'recenter t)
@@ -180,7 +170,6 @@
               (unless (executable-find search-command)
                 (error "'%s' is not installed" search-command))
               (error "Failed: '%s'" helm-ag2--last-query))))
-        (helm-ag2--remove-carrige-returns)
         (helm-ag2--save-current-context)))))
 
 (add-to-list 'debug-ignored-errors "^No ag output: ")
@@ -629,7 +618,6 @@ Special commands:
          (result (with-temp-buffer
                    (apply #'process-file (car helm-ag2--last-command) nil t nil
                           (cdr helm-ag2--last-command))
-                   (helm-ag2--remove-carrige-returns)
                    (helm-ag2--propertize-candidates helm-ag2--last-query)
                    (buffer-string))))
     (helm-ag2--put-result-in-save-buffer result)
@@ -932,12 +920,12 @@ Special commands:
     (when single-file
       (setq helm-ag2--search-this-file (car targets)))
     (helm-ag2--save-current-context)
-    (if (or (helm-ag2--windows-p) targets) ;; Path argument must be specified on Windows
+    (if single-file
         (helm-do-ag2--helm single-file)
       (let* ((helm-ag2--default-directory
               (file-name-as-directory (car helm-ag2--default-target)))
              (helm-ag2--default-target nil))
-        (helm-do-ag2--helm single-file)))))
+        (helm-do-ag2--helm nil)))))
 
 (provide 'helm-ag2)
 

--- a/helm-ag2.el
+++ b/helm-ag2.el
@@ -44,10 +44,10 @@
   (memq system-type '(ms-dos windows-nt)))
 
 (defcustom helm-ag2-base-command
-  (if (helm-ag2--windows-p)
-      '("ag" "--vimgrep")
+  (if (executable-find "rg")
+      '("rg" "--pcre2" "--color=never" "--no-heading" "--line-number")
     '("ag" "--nocolor" "--nogroup"))
-  "Base command of `ag'"
+  "Base command of `helm-ag2'"
   :type '(repeat (string)))
 
 (defcustom helm-ag2-insert-at-point 'symbol

--- a/helm-ag2.el
+++ b/helm-ag2.el
@@ -174,11 +174,8 @@
 
 (add-to-list 'debug-ignored-errors "^No ag output: ")
 
-(defsubst helm-ag2--vimgrep-option ()
-  (member "--vimgrep" helm-ag2--last-command))
-
 (defun helm-ag2--search-only-one-file-p ()
-  (when (and (not (helm-ag2--vimgrep-option)) (assoc 'single-file (helm-get-current-source)))
+  (when (assoc 'single-file (helm-get-current-source))
     (when (= (length helm-ag2--default-target) 1)
       (let ((target (car helm-ag2--default-target)))
         (unless (file-directory-p target)
@@ -392,10 +389,7 @@
   ;; $2: line
   ;; $3: match body
   ;; $4: file attributes part(filename, line, column)
-  (cond ((helm-ag2--vimgrep-option)
-         ;; context line of rg like: filename-line-content
-         "^\\(?4:\\(?:\\(?1:[^:\n]+\\)[:]\\(?2:[1-9][0-9]*\\)[:]\\([^:\n]+:\\)\\|\\(?1:.+\\)-\\(?2:[1-9][0-9]*\\)-\\)\\)\\(?3:[^\n]*\\)$")
-        (helm-ag2--search-this-file
+  (cond (helm-ag2--search-this-file
          "^\\(?4:\\(?2:[1-9][0-9]*\\)[:-]\\)\\(?3:.*\\)$")
         (t
          "^\\(?4:\\(?1:[^:]+\\):\\(?2:[1-9][0-9]*\\)[:-]\\)\\(?3:.*\\)$")))
@@ -733,8 +727,7 @@ Special commands:
     (goto-char (point-min))
     (forward-line 1)
     (let ((patterns (helm-ag2--highlight-patterns input)))
-      (cl-loop with one-file-p = (and (not (helm-ag2--vimgrep-option))
-                                      (helm-ag2--search-only-one-file-p))
+      (cl-loop with one-file-p = (helm-ag2--search-only-one-file-p)
                while (not (eobp))
                for num = 1 then (1+ num)
                do
@@ -832,8 +825,7 @@ Special commands:
 
 (defun helm-ag2--filter-one (candidate input)
   (let ((patterns (helm-ag2--highlight-patterns input))
-        (one-file-p (and (not (helm-ag2--vimgrep-option))
-                         (helm-ag2--search-only-one-file-p))))
+        (one-file-p (helm-ag2--search-only-one-file-p)))
     (if one-file-p
         (if (string-match "^\\([^:]+\\):\\(.*\\)$" candidate)
             (cons (concat (propertize (match-string-no-properties 1 candidate)

--- a/helm-ag2.el
+++ b/helm-ag2.el
@@ -756,17 +756,15 @@ Special commands:
                  (forward-line 1))))))
 
 (defun helm-ag2--project-root ()
-  (cl-loop for dir in '(".git/" ".git") ;; consider symlink case
-           when (locate-dominating-file default-directory dir)
-           return it))
+  (or (cl-loop for dir in '(".git/" ".git") ;; consider symlink case
+               when (locate-dominating-file default-directory dir)
+               return it)
+      (error "Could not find the project root. This command works only in git repository")))
 
 ;;;###autoload
 (defun helm-ag2-project-root ()
   (interactive)
-  (let ((rootdir (helm-ag2--project-root)))
-    (unless rootdir
-      (error "Could not find the project root. You need to 'git init'"))
-    (helm-ag2 rootdir)))
+  (helm-ag2 (helm-ag2--project-root)))
 
 (defvar helm-do-ag2--commands)
 
@@ -918,6 +916,11 @@ Special commands:
               (file-name-as-directory (car helm-ag2--default-target)))
              (helm-ag2--default-target nil))
         (helm-do-ag2--helm nil)))))
+
+;;;###autoload
+(defun helm-do-ag2-project-root ()
+  (interactive)
+  (helm-do-ag2 (list (helm-ag2-project-root))))
 
 (provide 'helm-ag2)
 


### PR DESCRIPTION
- Drop Windows support
- Use ripgrep as default if it is already installed
- Remove `--vimgrep` option check. I think both `ag` and `rg` work well without this option
- Add new command that executes helm-do-ag2 at project root